### PR TITLE
Add endpoints to work with task lists

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
+from app.routers import task_list
 
 from infrastructure.db.base import Base
 from infrastructure.db.session import engine
 from infrastructure.db import models
 
 app = FastAPI()
+app.include_router(task_list.router)
 
 @app.get("/")
 def read_root():

--- a/app/routers/task_list.py
+++ b/app/routers/task_list.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter, status, HTTPException
+from app.schemas.task_list import TaskListCreate, TaskListResponse
+from usecases.task_list.create import CreateTaskListUseCase
+from usecases.task_list.update import UpdateTaskListUseCase
+from usecases.task_list.delete import DeleteTaskListUseCase
+from infrastructure.repositories.task_list import SqlAlchemyTaskListRepository
+
+from uuid import UUID
+
+router = APIRouter(prefix="/task-lists", tags=["Task Lists"])
+
+@router.post("/", response_model=TaskListResponse, status_code=status.HTTP_201_CREATED)
+def create_task_list(payload: TaskListCreate):
+    repo = SqlAlchemyTaskListRepository()
+    usecase = CreateTaskListUseCase(repo)
+    task_list = usecase.execute(name=payload.name, description=payload.description)
+    return TaskListResponse(**task_list.model_dump())
+
+@router.get("/", response_model=list[TaskListResponse])
+def get_all_task_lists():
+    repo = SqlAlchemyTaskListRepository()
+    task_lists = repo.get_all_task_lists()
+    return [TaskListResponse(**tl.model_dump()) for tl in task_lists]
+
+@router.get("/{task_list_id}", response_model=TaskListResponse)
+def get_task_list(task_list_id: UUID):
+    repo = SqlAlchemyTaskListRepository()
+    task_list = repo.get_by_id(task_list_id)
+    if not task_list:
+        raise HTTPException(status_code=404, detail="Task list not found")
+    return TaskListResponse(**task_list.model_dump())
+
+@router.put("/{task_list_id}", response_model=TaskListResponse)
+def update_task_list(task_list_id: UUID, payload: TaskListCreate):
+    repo = SqlAlchemyTaskListRepository()
+    existing = repo.get_by_id(task_list_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Task list not found")
+
+    updated = existing.model_copy(update={
+        "name": payload.name,
+        "description": payload.description
+    })
+
+    usecase = UpdateTaskListUseCase(repo)
+    result = usecase.execute(updated)
+    return TaskListResponse(**result.model_dump())
+
+@router.delete("/{task_list_id}", status_code=204)
+def delete_task_list(task_list_id: UUID):
+    repo = SqlAlchemyTaskListRepository()
+    task_list = repo.get_by_id(task_list_id)
+    if not task_list:
+        raise HTTPException(status_code=404, detail="Task list not found")
+
+    usecase = DeleteTaskListUseCase(repo)
+    usecase.execute(task_list_id)
+    return
+

--- a/app/schemas/task_list.py
+++ b/app/schemas/task_list.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import Optional
+from uuid import UUID
+from datetime import datetime
+
+class TaskListCreate(BaseModel):
+    name: str
+    description: Optional[str] = ""
+
+class TaskListResponse(BaseModel):
+    id: UUID
+    name: str
+    description: Optional[str]
+    created_at: datetime
+    updated_at: datetime


### PR DESCRIPTION
### Background
Now that we have our repositories and usecases, we only need a way for the user to interact with all the logic.

### Changes
- Added a schema to adapt the ORM response
- Added endpoints to do the CRUD for tasks list
- Included all the endpoints in the app

### Result
The app is ready to pass task list data to a frontend app thanks to the created endpoints.